### PR TITLE
Fixes typo that makes makeTable crash

### DIFF
--- a/js/sheetsee.js
+++ b/js/sheetsee.js
@@ -25365,7 +25365,7 @@ module.exports.table = table
 function table(data, opts) {
   if (opts.templateID) {
     var templateID = opts.templateID
-  } else var templateID = opts.targetDiv.replace("#", "")
+  } else var templateID = opts.tableDiv.replace("#", "")
   var tableContents = ich[templateID]({
     rows: data
   })


### PR DESCRIPTION
I was trying out the examples, but makeTable didn't work. Figured out that there was a typo in the latest version of sheetsee.js (May 25). When I tried out the previous version, it worked. [Screenshot with some info](http://i.imgur.com/NHTnASl.png).

ps: sorry about that first pull that I clumsily opened and closed
pps: loving sheetsee, hope to contribute an example soon
